### PR TITLE
catch socket error (such as ECONNRESET)

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -34,6 +34,11 @@ module.exports = function(socketStream) {
         ss.log("←".green, ("Session ID " + sessionID + " - Console client has disconnected").grey);
       });
 
+      // Handle ECONNRESET
+      socket.on('error', function(e) {
+        ss.log("!".red, ("Socket Error " + e).yellow);
+      });
+
       // Make all Request Responders with a 'console' interface available over the REPL
       for (var id in serverInstance.responders) {
 
@@ -84,13 +89,13 @@ module.exports = function(socketStream) {
         terminal:     true,
         useGlobal:    true
       };
-      
+
       // Start a REPL for this client
       var rconsole = repl.start(replOptions);
       rconsole.context.ss = ss;
 
     });
-    
+
     server.listen(port);
 
   });


### PR DESCRIPTION
This prevents the socket from throwing an exception taking the whole application with it.

This is easily tested by running an SS app with ss-console started and running nmap (does half-socket opens).

So...

```
nmap localhost
```

will result in:

```
Aug 07 02:54:25 lophilo node[571]: → Session ID Xv9W2t/PdGQ/cUDRHKf6ANxq - Console client has connected
Aug 07 02:54:25 lophilo node[571]: events.js:68
Aug 07 02:54:25 lophilo node[571]: throw arguments[1]; // Unhandled 'error' event
Aug 07 02:54:25 lophilo node[571]: ^
Aug 07 02:54:25 lophilo node[571]: Error: write ECONNRESET
```

...whereas the node exits.
