### PR TITLE
replace process.stdin.resume() with .read() to work with node v0.10 streams

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -21,7 +21,7 @@ module.exports = function(host, port) {
   sock.pipe(process.stdout);
 
   sock.on('connect', function () {
-    process.stdin.resume();
+    process.stdin.read();
     process.stdin.setRawMode(true);
   });
 


### PR DESCRIPTION
fixes #6.

not tested for node v0.8, if it doesn't work might be necessary to use [readable-stream](https://github.com/isaacs/readable-stream).
